### PR TITLE
Some enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ Create a new item and add it to our collection.
 Results: 2/2 tests passed.
 ```
 
+Note:  When testing the API, all your routes should have `examples`, which
+might be empty. This is to ensure all routes are documented and you are well
+aware some endpoints are lacking tests.
+
+
 Note: You can also document and test each API resource individually, but remember to provide the correct base path like so:
 
 ```markdown

--- a/README.md
+++ b/README.md
@@ -131,7 +131,6 @@ Note:  When testing the API, all your routes should have `examples`, which
 might be empty. This is to ensure all routes are documented and you are well
 aware some endpoints are lacking tests.
 
-
 Note: You can also document and test each API resource individually, but remember to provide the correct base path like so:
 
 ```markdown

--- a/selfapi.js
+++ b/selfapi.js
@@ -366,7 +366,7 @@ API.prototype = {
       }, 10000);
 
       if ('body' in exampleRequest) {
-        request.write(exampleRequest.body);
+        request.write(maybeJsonStringify(exampleRequest.body));
       }
       request.end();
     });

--- a/selfapi.js
+++ b/selfapi.js
@@ -421,6 +421,15 @@ API.prototype = {
         var request = example.request || {};
         if (request.headers || request.body) {
           html += '<h3>Input</h3>\n<pre>';
+
+          // Format example-specific URL
+          var exampleURL = method.toUpperCase() + ' ' + fullPath;
+          var requestParameters = request.urlParameters || {};
+          for (var requestParam in requestParameters) {
+            exampleURL = exampleURL.replace(':' + requestParam, requestParameters[requestParam]);
+          }
+          html += exampleURL + '\n';
+
           var requestHeaders = request.headers || {};
           for (var header in requestHeaders) {
             html += header + ': ' + requestHeaders[header] + '\n';
@@ -488,6 +497,15 @@ API.prototype = {
         var request = example.request || {};
         if (request.headers || request.body) {
           markdown += '### Example input:\n\n';
+
+          // Format example-specific URL
+          var exampleURL = '    ' + method.toUpperCase() + ' ' + fullPath;
+          var requestParameters = request.urlParameters || {};
+          for (var requestParam in requestParameters) {
+            exampleURL = exampleURL.replace(':' + requestParam, requestParameters[requestParam]);
+          }
+          markdown += exampleURL + '\n';
+
           var requestHeaders = request.headers || {};
           for (var header in requestHeaders) {
             markdown += '    ' + header + ': ' + requestHeaders[header] + '\n';

--- a/selfapi.js
+++ b/selfapi.js
@@ -373,21 +373,18 @@ API.prototype = {
   },
 
   // Build index routes.
-  buildIndexRoutes: function (basePath) {
+  toAPIIndex: function (basePath) {
     var fullPath = normalizePath(this.path, basePath) || '/';
-    this.get({
-      title: 'Index',
-      handler: (request, response) => {
-        var routes = {};
-        Object.keys(this.children).forEach(function (child) {
-          if (child == "null") {
-            return;
-          }
-          routes[child.replace(/^\//, '')] = nodepath.join(fullPath, child);
-        });
-        response.json(routes);
-      }
-    })
+    return function () {
+      var routes = {};
+      Object.keys(this.children).forEach(function (child) {
+        if (child == "null") {
+          return;
+        }
+        routes[child.replace(/^\//, '')] = nodepath.join(fullPath, child);
+      });
+      return routes;
+    };
   },
 
   // Export API documentation as HTML.

--- a/selfapi.js
+++ b/selfapi.js
@@ -580,8 +580,8 @@ function getHandlerExporter (app) {
   // `app` is an express-like server app.
   return function (method, path, parameters) {
     // Support restify.
-    if (method === 'delete' && ('del' in app)) {
-      method = 'del';
+    if (method === 'del' && ('delete' in app)) {
+      method = 'delete';
     }
     app[method](path, parameters.handler);
   };

--- a/selfapi.js
+++ b/selfapi.js
@@ -402,7 +402,7 @@ API.prototype = {
         '<h1 id="' + getAnchor(this.title) + '">' + this.title + '</h1>\n';
     }
     if (this.description) {
-      html += '<p>' + this.description + '</p>\n';
+      html += '<p>' + this.description.replace(/\n/g, '<br/>') + '</p>\n';
     }
 
     // Export own request handlers.
@@ -412,7 +412,7 @@ API.prototype = {
       html += '<h2 id="' + getAnchor(title) + '">' + title + '</h2>\n';
       html += '<pre>' + method.toUpperCase() + ' ' + fullPath + '</pre>\n';
       if (handler.description) {
-        html += '<p>' + handler.description + '</p>\n';
+        html += '<p>' + handler.description.replace(/\n/g, '<br/>') + '</p>\n';
       }
 
       if (handler.examples && handler.examples.length > 0) {

--- a/selfapi.js
+++ b/selfapi.js
@@ -419,7 +419,7 @@ API.prototype = {
         var example = handler.examples[0];
 
         var request = example.request || {};
-        if (request.headers || request.body) {
+        if (request.headers || request.body || request.urlParameters) {
           html += '<h3>Input</h3>\n<pre>';
 
           // Format example-specific URL
@@ -495,7 +495,7 @@ API.prototype = {
         var example = handler.examples[0];
 
         var request = example.request || {};
-        if (request.headers || request.body) {
+        if (request.headers || request.body || request.urlParameters) {
           markdown += '### Example input:\n\n';
 
           // Format example-specific URL

--- a/selfapi.js
+++ b/selfapi.js
@@ -6,6 +6,13 @@ var https = require('https');
 var nodepath = require('path');
 var url = require('url');
 
+function ensureSerialized(strOrObject, spaces=null) {
+  if (strOrObject instanceof Object) {
+    return JSON.stringify(strOrObject, null, spaces);
+  }
+  return strOrObject;
+}
+
 // Simple, self-documenting and self-testing API system.
 function API (parameters) {
   // Own API resource prefix (e.g. '/resource').
@@ -304,7 +311,7 @@ API.prototype = {
 
         var expectedBody = null;
         if ('body' in exampleResponse) {
-          expectedBody = exampleResponse.body.trim();
+          expectedBody = ensureSerialized(exampleResponse.body).trim();
         }
 
         var body = '';
@@ -419,7 +426,7 @@ API.prototype = {
             html += header + ': ' + requestHeaders[header] + '\n';
           }
           if (request.body) {
-            html += '\n' + request.body.trim() + '\n';
+            html += '\n' + ensureSerialized(request.body, 4).trim() + '\n';
           }
           html += '</pre>\n';
         }
@@ -436,7 +443,7 @@ API.prototype = {
             html += header + ': ' + responseHeaders[header] + '\n';
           }
           if (response.body) {
-            html += '\n' + response.body.trim() + '\n';
+            html += '\n' + ensureSerialized(response.body, 4).trim() + '\n';
           }
           html += '</pre>\n';
         }
@@ -487,7 +494,7 @@ API.prototype = {
           }
           if (request.body) {
             var requestBody = '    ' +
-              request.body.trim().replace(/\n/g, '\n    ');
+              ensureSerialized(request.body, 4).trim().replace(/\n/g, '\n    ');
             markdown += '    \n' + requestBody + '\n';
           }
           markdown += '\n';
@@ -506,7 +513,7 @@ API.prototype = {
           }
           if (response.body) {
             var responseBody = '    ' +
-              response.body.trim().replace(/\n/g, '\n    ');
+              ensureSerialized(response.body, 4).trim().replace(/\n/g, '\n    ');
             markdown += '    \n' + responseBody + '\n';
           }
           markdown += '\n';

--- a/selfapi.js
+++ b/selfapi.js
@@ -134,7 +134,10 @@ API.prototype = {
     for (var method in self.handlers) {
       var handler = self.handlers[method];
       if (!handler.examples) {
-        throw `Handler ${method.toUpperCase()} ${this.path} does not have examples!`;
+        throw (
+          'Handler ' + method.toUpperCase() + ' ' + this.path +
+            ' does not have examples!'
+        );
       }
       handler.examples.forEach(function (example) {
         var test =
@@ -603,14 +606,11 @@ function getHandlerExporter (app) {
 
 // Stringify Objects, leave non-Objects untouched (e.g. Strings).
 function maybeJsonStringify (value) {
-  if (value instanceof Object) {
-    return JSON.stringify(
-      value,
-      options.jsonStringifyReplacer,
-      options.jsonStringifySpaces
-    );
+  if (!(value instanceof Object)) {
+    return value;
   }
-  return value;
+  return JSON.stringify(value, options.jsonStringifyReplacer,
+    options.jsonStringifySpaces);
 }
 
 // Exported `selfapi` function to create an API tree.

--- a/selfapi.js
+++ b/selfapi.js
@@ -374,6 +374,24 @@ API.prototype = {
     });
   },
 
+  // Build index routes.
+  buildIndexRoutes: function (basePath) {
+      var fullPath = normalizePath(this.path, basePath) || '/';
+      this.get({
+          title: 'Index',
+          handler: (request, response) => {
+              var routes = {};
+              Object.keys(this.children).forEach(child => {
+                  if (child == "null") {
+                      return;
+                  }
+                  routes[child.replace(/^\//, '')] = nodepath.join(fullPath, child);
+              });
+              response.json(routes);
+          }
+      })
+  },
+
   // Export API documentation as HTML.
   toHTML: function (basePath, anchors) {
     var fullPath = normalizePath(this.path, basePath) || '/';

--- a/selfapi.js
+++ b/selfapi.js
@@ -133,6 +133,9 @@ API.prototype = {
     // Export own request handler examples as test functions.
     for (var method in self.handlers) {
       var handler = self.handlers[method];
+      if (!handler.examples) {
+        throw `Handler ${method.toUpperCase()} ${this.path} does not have examples!`;
+      }
       handler.examples.forEach(function (example) {
         var test =
           self.testHandlerExample.bind(self, baseUrl, method, handler, example);

--- a/selfapi.js
+++ b/selfapi.js
@@ -373,12 +373,14 @@ API.prototype = {
   },
 
   // Build index routes.
-  toAPIIndex: function (basePath) {
-    var fullPath = normalizePath(this.path, basePath) || '/';
+  toAPIIndex: function (baseUrl) {
+    var fullUrl = url.parse(String(baseUrl || '/'));
+    fullUrl.pathname = normalizePath(this.path, fullUrl.pathname);
+    fullUrl = url.format(fullUrl);
 
     var routes = {};
     Object.keys(this.children).forEach(function (child) {
-      routes[child.replace(/^\//, '')] = nodepath.join(fullPath, child);
+      routes[child.replace(/^\//, '')] = nodepath.join(fullUrl, child);
     });
     return routes;
   },

--- a/selfapi.js
+++ b/selfapi.js
@@ -7,8 +7,8 @@ var nodepath = require('path');
 var url = require('url');
 
 var options = {
-    jsonStringifyReplacer: null,
-    jsonStringifySpaces: 2
+  jsonStringifyReplacer: null,
+  jsonStringifySpaces: 2
 };
 
 // Simple, self-documenting and self-testing API system.
@@ -309,7 +309,7 @@ API.prototype = {
 
         var expectedBody = null;
         if ('body' in exampleResponse) {
-          expectedBody = jsonStringify(exampleResponse.body).trim();
+          expectedBody = maybeJsonStringify(exampleResponse.body).trim();
         }
 
         var body = '';
@@ -375,16 +375,12 @@ API.prototype = {
   // Build index routes.
   toAPIIndex: function (basePath) {
     var fullPath = normalizePath(this.path, basePath) || '/';
-    return function () {
-      var routes = {};
-      Object.keys(this.children).forEach(function (child) {
-        if (child == "null") {
-          return;
-        }
-        routes[child.replace(/^\//, '')] = nodepath.join(fullPath, child);
-      });
-      return routes;
-    };
+
+    var routes = {};
+    Object.keys(this.children).forEach(function (child) {
+      routes[child.replace(/^\//, '')] = nodepath.join(fullPath, child);
+    });
+    return routes;
   },
 
   // Export API documentation as HTML.
@@ -448,7 +444,7 @@ API.prototype = {
             html += header + ': ' + requestHeaders[header] + '\n';
           }
           if (request.body) {
-            html += '\n' + jsonStringify(request.body).trim() + '\n';
+            html += '\n' + maybeJsonStringify(request.body).trim() + '\n';
           }
           html += '</pre>\n';
         }
@@ -465,7 +461,7 @@ API.prototype = {
             html += header + ': ' + responseHeaders[header] + '\n';
           }
           if (response.body) {
-            html += '\n' + jsonStringify(response.body).trim() + '\n';
+            html += '\n' + maybeJsonStringify(response.body).trim() + '\n';
           }
           html += '</pre>\n';
         }
@@ -525,7 +521,7 @@ API.prototype = {
           }
           if (request.body) {
             var requestBody = '    ' +
-              jsonStringify(request.body).trim().replace(/\n/g, '\n    ');
+              maybeJsonStringify(request.body).trim().replace(/\n/g, '\n    ');
             markdown += '    \n' + requestBody + '\n';
           }
           markdown += '\n';
@@ -544,7 +540,7 @@ API.prototype = {
           }
           if (response.body) {
             var responseBody = '    ' +
-              jsonStringify(response.body).trim().replace(/\n/g, '\n    ');
+              maybeJsonStringify(response.body).trim().replace(/\n/g, '\n    ');
             markdown += '    \n' + responseBody + '\n';
           }
           markdown += '\n';
@@ -600,12 +596,16 @@ function getHandlerExporter (app) {
   };
 }
 
-// Stringify object, pass down strings
-function jsonStringify(strOrObject) {
-  if (strOrObject instanceof Object) {
-    return JSON.stringify(strOrObject, options.jsonStringifyReplacer, options.jsonStringifySpaces);
+// Stringify Objects, leave non-Objects untouched (e.g. Strings).
+function maybeJsonStringify (value) {
+  if (value instanceof Object) {
+    return JSON.stringify(
+      value,
+      options.jsonStringifyReplacer,
+      options.jsonStringifySpaces
+    );
   }
-  return strOrObject;
+  return value;
 }
 
 // Exported `selfapi` function to create an API tree.
@@ -674,4 +674,5 @@ function selfapi (/* parent, …overrides, child */) {
 }
 
 selfapi.API = API;
+selfapi.options = options;
 module.exports = selfapi;


### PR DESCRIPTION
Here are a couple of enhancements I am using for Kresus:

* Allow body to be a plain JS object (and be JSON.stringify-ed on need). I find it clearer to write an object, with indentation and so on, rather than a JSON representation. And I feel like this can be useful for tests as we could compare objects directly instead of an output value (did not test anything like this for now).
* Show values of URL parameters in examples URLs, not sure this is the best implementation in terms of styling. Output these URLs even if there is no body
* Convert new lines to br tags in HTML descriptions.
* Remove an express deprecation warning with `del` method.

Thanks!