### PR TITLE
Support validation functions in API handler examples.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "selfapi",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Simple, self-documenting and self-testing API system for Node.js.",
   "keywords": [
     "api",


### PR DESCRIPTION
This implements validation functions in SelfAPI handler examples. They look like this:

```js
api.get('/dice', {
  title: 'Roll a dice',
  handler (request, response) {
    var result = Math.floor(Math.random() * 6) + 1;
    response.end(String(result));
  },
  examples: [{
    response: {
      body: function (body) {
        var result = parseInt(body.trim(), 10);
        return result > 0 && result <= 6;
      }
    }
  }]
});
```

My only worry is that these example functions won't appear as values inside the documentation (because they're not explicit example values).

To work around this, we could either encourage SelfAPI users to use hard-coded values in the first example (self-documentation only uses the first example in the list), and then validation functions in later examples, or we could do some something similar to test logs, which stringify validation functions like so:

```js
{
  "failed": [
    {
      "handler": "Get something",
      "method": "get",
      "uri": "/api/thing",
      "request": {},
      "expectedResponse": {
        "status": "function (status) { return status >= 200 && status < 300; }"
      },
      "actualResponse": {
        "status": 500
      }
    }
  ],
  "passed": []
}
```
